### PR TITLE
Add harmony as dependency to whistle production

### DIFF
--- a/wstlr/conceptmap.py
+++ b/wstlr/conceptmap.py
@@ -353,7 +353,7 @@ def BuildConceptMap(csvfilename, curies):
     outname = ".".join(csvfilename.split(".")[0:-1]) + ".json"
 
     # Skip this step if the json file is newer
-    if not Path(outname).exists() or \
+    if (not Path(outname).exists()) or \
         (Path(csvfilename).stat().st_mtime > Path(outname).stat().st_mtime):
 
         with open(csvfilename, 'rt') as f:
@@ -431,6 +431,7 @@ def BuildConceptMap(csvfilename, curies):
             
             with open(outname, mode='wt') as f:
                 f.write(json.dumps(concept_map, indent=2))
+    return Path(outname).stat().st_mtime
 
 def Exec(argv=None):
     if argv is None:


### PR DESCRIPTION
During the rush to get data loaded for the Mar 21 deadline, I encountered more than a few puzzling issues where codes weren't appearing despite changes to the ETL and harmony prefill. It turns out that the harmony production wasn't not triggering a call to whistle, so it kept skipping the whistle part since none of it's dependencies had been updated...This now works correctly. 

Fixes [Issue 2](https://github.com/NIH-NCPI/ncpi-whistler/issues/2)